### PR TITLE
Version 646.0 - Fix missing genesis block loading

### DIFF
--- a/src/main/java/co/nyzo/verifier/Verifier.java
+++ b/src/main/java/co/nyzo/verifier/Verifier.java
@@ -331,6 +331,7 @@ public class Verifier {
                 channel.close();
 
                 buffer.rewind();
+                short amountOfBlocks = buffer.getShort();
                 genesisBlock = Block.fromByteBuffer(buffer);
 
                 LogUtil.println("[Verifier][loadGenesisBlock]: fetched block: " + genesisBlock.toStringVerbose());

--- a/src/main/java/co/nyzo/verifier/Version.java
+++ b/src/main/java/co/nyzo/verifier/Version.java
@@ -2,8 +2,8 @@ package co.nyzo.verifier;
 
 public class Version {
 
-    private int version = 645;
-    private int subVersion = 4;
+    private int version = 646;
+    private int subVersion = 0;
 
     public Version(){
 


### PR DESCRIPTION
Verifier.loadGenesisBlock did not read the amount of blocks before passing the buffer to fromByteBuffer. Subsequent reads were offset by 2 bytes until an exception occurred.

![image](https://github.com/user-attachments/assets/9ddf23cc-bdd0-4228-ad67-418bbe7fe0ec)
